### PR TITLE
Add git-filter-repo to installation process

### DIFF
--- a/manjaro19/basic/install_extras2.sh
+++ b/manjaro19/basic/install_extras2.sh
@@ -24,3 +24,6 @@ yay -S --needed --nocleanmenu  --nodiffmenu --noconfirm drawio-desktop flameshot
 
 # Github-Desktop
 yay -S --needed --nocleanmenu  --nodiffmenu --noconfirm github-desktop-bin
+
+# Git-filter-repo
+yay -S --needed --nocleanmenu --nodiffmenu --noconfirm git-filter-repo


### PR DESCRIPTION
Add git-filter-repo to installation process.
 - git filter-branch has many pitfalls, and is no longer the recommended way to rewrite history. Instead, consider using git-filter-repo, which is a Python script that does a better job for most applications where you would normally turn to filter-branch.